### PR TITLE
Docker support

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,64 @@
+name: Build
+
+# Following multi arch build tutorial: https://dev.to/cloudx/multi-arch-docker-images-the-easy-way-with-github-actions-4k54
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'master'
+      - 'dev'
+    tags:
+      - 'v*.*.*'
+    pull_request:
+      branches:
+      - 'master'
+
+
+permissions: 
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Docker meta
+        id: meta_promalertproxy # you'll use this in the next step
+        uses: docker/metadata-action@v3
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ghcr.io/${{ github.repository_owner }}/promalertproxy
+          # Docker tags based on the following events/attributes
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64/v8
+          tags: ${{ steps.meta_promalertproxy.outputs.tags }}
+          push: ${{ github.event_name != 'pull_request' }}
+          labels: ${{ steps.meta_promalertproxy.outputs.labels }}
+
+
+      

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM debian:latest
+
+RUN apt-get -y update && \
+    apt-get -y upgrade
+
+
+WORKDIR /app
+
+# setup perl dependencies
+RUN apt-get install -y carton make gcc
+# libemail-sender-perl provies Email::Sender::Transport::SMTP which will can used as a transport for email alerts
+RUN apt-get install -y libemail-sender-perl
+COPY cpanfile ./
+RUN carton install
+
+COPY lib ./lib
+COPY bin ./bin/
+
+
+EXPOSE 8080
+
+ENV DISPATCHOULI_STDERR=1
+CMD carton exec perl -I lib/ bin/promalertproxy -c config.toml


### PR DESCRIPTION
This adds a Dockerfile anyone can use to build promalertproxy.

It also adds a github workflow so any push to 'master' or 'dev' branches will build an image automatically tagged with their branch name.  eg you can pull it with `docker pull ghcr.io/robn/promalertproxy:master`.

I included 'dev' for my own convenience.  When developing on my own fork i can push to 'dev' and have it build automatically (under my own namespace) which is useful because I develop on my laptop but need to test arm64 which is my deployment target.   



